### PR TITLE
Add more webpack plugins

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -32,6 +32,7 @@ module.exports = {
     new ExtractTextPlugin('style.css', {
       allChunks: true
     }),
+    new webpack.NoErrorsPlugin(),
     new webpack.ProvidePlugin({
       fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch'
     })

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -33,6 +33,7 @@ module.exports = {
       allChunks: true
     }),
     new webpack.NoErrorsPlugin(),
+    new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.ProvidePlugin({
       fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch'
     })


### PR DESCRIPTION
Add:

- NoErrorsPlugin: Keeps webpack from emitting its build products if there are any errors.  That way, the hot-reloading in the browser won’t get broken and require a page refresh.

- OccurenceOrderPlugin: Reduces overall file size, results in more predictable ordering of the build product, and is recommended in the webpack documentation.