### PR TITLE
Add Starter Application

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,21 @@ The boilerplate includes all of the tools that we're currently using in our Reac
 
 We assume some familiarity with the React/Redux ecosystem, including Babel and Webpack.
 
+## Getting Started
+
+After creating the repository for your project, copy the files from this repo into your working directory.  Be careful not to overwrite your `README.md` or `.gitignore`.  You may want to merge the boilerplate's `.gitignore` with your own.  Make sure you copy `.eslintrc`; that one's easy to miss when copying from the command-line, since it's a hidden file.
+
+We've included an extremely simple starter application in the boilerplate.  To try it out, run `npm run starterapp` and navigate to `localhost:8080` in your browser.  You should see a heading that says `Zeal React Boilerplate Test`.  If you look in the browser's console, you should see a message indicating that Hot Module Replacement is enabled.
+
+### Cleaning Up the Starter App
+
+Once you've got your front-end application embedded into your real back-end server, you'll want to clean out the starter app.  To do that:
+
+* Delete `index.html`
+* Delete `webpack/starterApp.js`
+* Delete the `starterapp` script line from `package.json`
+* Change the contents of `client/components/App/index.js` as appropriate for your application.
+
 ## Notes of Interest
 
 * We include `flux-standard-action` to indicate that our intention is to use that format for our actions.  We don't currently import it anywhere, but if you're so inclined, you can use its `isFSA()` function to check your actions in tests or as a guard in the reducer returned from `createReducer()`.

--- a/client/components/App/index.js
+++ b/client/components/App/index.js
@@ -1,11 +1,16 @@
-import { PropTypes } from 'react'
+import React, { PropTypes } from 'react'
 
 const propTypes = {
   children: PropTypes.element
 }
 
 export default function App({ children }) {
-  return children
+  return (
+    <div>
+      <h1>Zeal React Boilerplate Test</h1>
+      {children}
+    </div>
+  )
 }
 
 App.propTypes = propTypes

--- a/index.html
+++ b/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <title>Zeal React Boilerplate Test</title>
+  </head>
+  <body>
+    <div id="root">
+    </div>
+    <script src="/public/client.js"></script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "dev": "webpack-dev-server --config webpack/development.js --devtool eval --progress --colors --hot",
     "lint": "eslint client/*",
     "postinstall": "npm run build",
+    "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot",
     "test": "env NODE_PATH=$NODE_PATH:$PWD/client ./node_modules/.bin/mocha",
     "test:debug": "./node_modules/.bin/karma start test/karma.conf.js",
     "test:watch": "npm run test -- --watch"

--- a/webpack/starterApp.js
+++ b/webpack/starterApp.js
@@ -1,0 +1,5 @@
+const config = require('./development')
+
+config.output.publicPath = '/public'
+
+module.exports = config


### PR DESCRIPTION
* Use a separate webpack configuration for the starter app; it needs a different publicPath in order to work properly.
* Add a `starterapp` script to `package.json` for running the starter
app.
* Add a heading to the `App` component so that there’s something on the page.
* Add Getting Started instructions to the README