### PR TITLE
Fix issue of identical css files

### DIFF
--- a/client/components/App/index.js
+++ b/client/components/App/index.js
@@ -4,10 +4,15 @@ const propTypes = {
   children: PropTypes.element
 }
 
+import styles from './styles.scss'
+
 export default function App({ children }) {
   return (
     <div>
-      <h1>Zeal React Boilerplate Test</h1>
+      <h1 className={styles.heading}>
+        Zeal React Boilerplate Test
+      </h1>
+
       {children}
     </div>
   )

--- a/client/components/App/styles.scss
+++ b/client/components/App/styles.scss
@@ -1,0 +1,11 @@
+.zeal {
+  background-color: #325559;
+  color: #D85226;
+}
+
+.heading {
+  composes: zeal;
+  margin: 50px;
+  padding: 50px;
+  text-align: center;
+}

--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Zeal React Boilerplate Test</title>
+    <link href="/public/client.css" rel="stylesheet" />
   </head>
   <body>
     <div id="root">

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -29,7 +29,7 @@ module.exports = {
     filename: 'client.js'
   },
   plugins: [
-    new ExtractTextPlugin('style.css', {
+    new ExtractTextPlugin('client.css', {
       allChunks: true
     }),
     new webpack.NoErrorsPlugin(),

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -12,9 +12,6 @@ config.module.loaders.push({
 })
 
 config.plugins.push(
-  new ExtractTextPlugin('client.css', {
-    allChunks: true
-  }),
   new webpack.DefinePlugin({
     'process.env': {
       NODE_ENV: JSON.stringify('production')


### PR DESCRIPTION
After starting to use the extract text plugin, our style.css and
client.css files started producing the exact same thing, which is a
combination of what both of them should have been producing
individually. The following changes have been made to address this:

- Add some css for testing and example usage
- Have the extract text plugin produce one single css file
- In production:
  - All styles get compiled into client.css
- In development:
  - Vendor css gets compiled into client.css
  - Your scss gets pushed into a style tag for live reloading