### PR TITLE
Split client and vendor css into different files

### DIFF
--- a/index.html
+++ b/index.html
@@ -2,6 +2,7 @@
 <html>
   <head>
     <title>Zeal React Boilerplate Test</title>
+    <link href="/public/vendor.css" rel="stylesheet" />
     <link href="/public/client.css" rel="stylesheet" />
   </head>
   <body>

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -2,6 +2,10 @@ const path = require('path')
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
+const extractCSS = new ExtractTextPlugin('vendor.css', {
+  allChunks: true
+})
+
 module.exports = {
   entry: [path.resolve(__dirname, '../client/index.js')],
   module: {
@@ -12,7 +16,7 @@ module.exports = {
         loaders: ['babel']
       }, {
         test: /\.css/,
-        loader: ExtractTextPlugin.extract('css')
+        loader: extractCSS.extract('css')
       }, {
         test: /\.(eot|woff|woff2|ttf|svg|png|jpg)$/,
         loader: 'url-loader?limit=30000&name=[name]-[hash].[ext]'
@@ -29,9 +33,7 @@ module.exports = {
     filename: 'client.js'
   },
   plugins: [
-    new ExtractTextPlugin('client.css', {
-      allChunks: true
-    }),
+    extractCSS,
     new webpack.NoErrorsPlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.ProvidePlugin({

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -24,7 +24,7 @@ config.plugins.push(
   }),
   new webpack.optimize.UglifyJsPlugin({
     compressor: {
-      screw_ie8: true,
+      screw_ie8: true, // eslint-disable-line camelcase
       warnings: false
     },
     sourceMap: false

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -2,9 +2,13 @@ const config = require('./base')
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
 
+const extractSCSS = new ExtractTextPlugin('client.css', {
+  allChunks: true
+})
+
 config.module.loaders.push({
   test: /\.scss$/,
-  loader: ExtractTextPlugin.extract(
+  loader: extractSCSS.extract(
     'style',
     'css?modules&importLoaders=1' +
       '&localIdentName=[local]__[hash:base64:5]!sass'
@@ -12,6 +16,7 @@ config.module.loaders.push({
 })
 
 config.plugins.push(
+  extractSCSS,
   new webpack.DefinePlugin({
     'process.env': {
       NODE_ENV: JSON.stringify('production')


### PR DESCRIPTION
Now vendor styles will always be loaded the same in any environment and
will always be free of custom styles. This allows you to rely on the
style loader for custom styles without anything bleeding through in the
vendor styles from old builds