### PR TITLE
Remove the NoErrorsPlugin

### DIFF
--- a/webpack/base.js
+++ b/webpack/base.js
@@ -34,7 +34,6 @@ module.exports = {
   },
   plugins: [
     extractCSS,
-    new webpack.NoErrorsPlugin(),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.ProvidePlugin({
       fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch'


### PR DESCRIPTION
It turns out that this plugin causes more trouble than it’s worth.  It
can result in the browser silently failing to update when there’s an
error, and you might not notice if you’re not watching your console.

Failing loudly is preferred to this, even if it requires a page refresh.