### PR TITLE
Fix lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_ENV=production ./node_modules/.bin/webpack",
     "dev": "webpack-dev-server --devtool eval --progress --colors --hot --history-api-fallback",
-    "lint": "eslint client/*",
+    "lint": "eslint 'client/**/*.js'",
     "postinstall": "npm run build",
     "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot --history-api-fallback",
     "test": "env NODE_PATH=$NODE_PATH:$PWD/client ./node_modules/.bin/mocha --opts client/__tests__/mocha.opts",


### PR DESCRIPTION
* Quote the file glob so that the shell doesn't expand it before it gets to eslint
* Explicitly lint only js files; otherwise, we get errors on scss and resource files