### PR TITLE
Remove jsx-chai

### DIFF
--- a/client/__tests__/setup.js
+++ b/client/__tests__/setup.js
@@ -1,3 +1,2 @@
 require('./cssModulesFix')
 require('babel-core/register')
-require('./specHelper')

--- a/client/__tests__/specHelper.js
+++ b/client/__tests__/specHelper.js
@@ -1,4 +1,0 @@
-import chai from 'chai'
-import jsxChai from 'jsx-chai'
-
-chai.use(jsxChai)

--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "flux-standard-action": "^0.6.0",
     "history": "^1.17.0",
     "imports-loader": "^0.6.5",
-    "jsx-chai": "^2.0.0",
     "karma": "^0.13.17",
     "karma-chai": "^0.1.0",
     "karma-chrome-launcher": "^0.2.2",


### PR DESCRIPTION
With expectReactShallow, we don’t really need jsx-chai any more, so
remove it from the project.

It was the only thing we had in `specHelper.js`, so eliminate that as
well.