### PR TITLE
Add shallowRender utility

### DIFF
--- a/client/utils/shallowRender.js
+++ b/client/utils/shallowRender.js
@@ -1,0 +1,8 @@
+import TestUtils from 'react-addons-test-utils'
+
+export default function(component) {
+  const renderer = TestUtils.createRenderer()
+
+  renderer.render(component)
+  return renderer.getRenderOutput()
+}


### PR DESCRIPTION
There are some component tests that don’t lend themselves well to
expect-react-shallow.

React’s test utils contain support for shallow rendering, but the API
is awkward.

Add a `shallowRender` utility function to get rid of the awkwardness.
In a spec, you can simply `shallowRender(<MyComponent />)` and then
make assertions against the rendered component.