### PR TITLE
Fake out image loading in Mocha tests

### DIFF
--- a/client/__tests__/setup.js
+++ b/client/__tests__/setup.js
@@ -1,2 +1,3 @@
 require('./cssModulesFix')
+require('./shimImageLoader')
 require('babel-core/register')

--- a/client/__tests__/shimImageLoader.js
+++ b/client/__tests__/shimImageLoader.js
@@ -1,0 +1,7 @@
+function shim(module, filepath) {
+  const src = `module.exports = '${filepath}';`
+
+  return module._compile(src) // eslint-disable-line no-underscore-dangle
+}
+
+require.extensions['.png'] = shim


### PR DESCRIPTION
When running a component test for a component that imports an image
file, Mocha will blow up.

To work around this, we add a fake image loader that just returns the
filename of the image (which is what our webpack file-loader
configuration will do).

References:
* http://stackoverflow.com/a/34074103/667070 shows the basic technique
of stubbing out image loading.
* http://stackoverflow.25lm.com/a/35542997 shows how to write a shim
that actually does something non-trivial