### PR TITLE
Add sass-lint

### DIFF
--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -1,0 +1,51 @@
+files:
+  include: 'client/**/*.scss'
+rules:
+  border-zero:
+    - 1
+    -
+      none
+
+  brace-style:
+    - 1
+    -
+      single-line: false
+
+  class-name-format:
+    - 1
+    -
+      allow-leading-underscore: false
+      convention: camelcase
+
+  force-attribute-nesting: 0
+  force-pseudo-nesting: 0
+
+  id-name-format:
+    - 1
+    -
+      allow-leading-underscore: false
+
+  mixins-before-declarations:
+    - 1
+    -
+      exclude:
+        - breakpoint
+        - mq
+
+  no-color-literals: 0
+  no-css-comments: 0
+
+  no-misspelled-properties:
+    - 1
+    -
+      'extra-properties':
+        - 'composes'
+
+  placeholder-in-extend: 0
+
+  property-sort-order:
+    - 1
+    -
+      ignore-custom-properties: true
+
+  variable-for-property: 0

--- a/.sass-lint.yml
+++ b/.sass-lint.yml
@@ -4,7 +4,7 @@ rules:
   border-zero:
     - 1
     -
-      none
+      convention: none
 
   brace-style:
     - 1

--- a/client/components/App/styles.scss
+++ b/client/components/App/styles.scss
@@ -1,6 +1,6 @@
 .zeal {
   background-color: #325559;
-  color: #D85226;
+  color: #d85226;
 }
 
 .heading {

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_ENV=production ./node_modules/.bin/webpack",
     "dev": "webpack-dev-server --devtool eval --progress --colors --hot --history-api-fallback",
-    "lint": "eslint 'client/**/*.js'",
+    "lint": "eslint 'client/**/*.js' && sass-lint -v",
     "postinstall": "npm run build",
     "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot --history-api-fallback",
     "test": "env NODE_PATH=$NODE_PATH:$PWD/client ./node_modules/.bin/mocha --opts client/__tests__/mocha.opts",
@@ -78,6 +78,7 @@
     "redux-api-middleware": "^1.0.0-beta3",
     "redux-form": "^4.1.2",
     "redux-thunk": "^1.0.3",
+    "sass-lint": "^1.5.1",
     "sass-loader": "^3.1.2",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",

--- a/package.json
+++ b/package.json
@@ -80,6 +80,7 @@
     "redux-thunk": "^1.0.3",
     "sass-lint": "^1.5.1",
     "sass-loader": "^3.1.2",
+    "sasslint-loader": "0.0.1",
     "style-loader": "^0.13.0",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -26,6 +26,10 @@ module.exports = {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'eslint-loader'
+    }, {
+      test: /\.scss$/,
+      exclude: /node_modules/,
+      loader: 'sasslint-loader'
     }]
   },
   output: {
@@ -42,5 +46,8 @@ module.exports = {
   resolve: {
     root: path.resolve(__dirname, '../client'),
     extensions: ['', '.js']
+  },
+  sasslint: {
+    configFile: path.resolve(__dirname, '../.sass-lint.yml')
   }
 }


### PR DESCRIPTION
Add sass-lint to the project.

* Run sass-lint as part of `npm run lint`
* Use the default rules with some overrides based on discussion with
@tyarrish, and also overrides that conform to using CSS modules.
* NOTE: If you run sass-lint without the `-v` flag, it doesn’t report
any errors.

TODO:
- [x] Add a sass-lint webpack loader