### PR TITLE
Bump babel version

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,8 +29,8 @@
   },
   "private": true,
   "dependencies": {
-    "babel": "^6.3.26",
-    "babel-core": "^6.3.26",
+    "babel": "^6.5.2",
+    "babel-core": "^6.5.2",
     "babel-eslint": "^4.1.8",
     "babel-loader": "^6.2.0",
     "babel-plugin-transform-decorators-legacy": "^1.3.4",


### PR DESCRIPTION
Babel versions between 6.4 and 6.5.1 would require a semi-colon after
every static class property.  6.5.2 fixes that, so we want at least
that version.