### PR TITLE
More debuggable CSS module names

### DIFF
--- a/webpack/development.js
+++ b/webpack/development.js
@@ -15,7 +15,7 @@ config.module.loaders.push({
   loaders: [
     'style',
     'css?modules&importLoaders=1' +
-      '&localIdentName=[local]__[hash:base64:5]!sass'
+      '&localIdentName=[path][local]__[hash:base64:5]!sass'
   ]
 })
 


### PR DESCRIPTION
In development, include `[path]` in the CSS module names to help with
debugging in the browser.

We could also do this in production, but we may not want to reveal that much information about the structure of our React components.