### PR TITLE
Use css-loader/locals for Mocha tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "sass-lint": "^1.5.1",
     "sass-loader": "^3.1.2",
     "sasslint-loader": "0.0.1",
-    "style-loader": "magalhas/style-loader#6ffa6df",
+    "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",
     "webpack-dev-server": "1.14.0",

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -17,13 +17,6 @@ module.exports = {
         exclude: /node_modules/,
         loaders: ['babel']
       }, {
-        test: /\.scss$/,
-        loaders: [
-          'style',
-          'css?modules&importLoaders=1' +
-            '&localIdentName=[path][local]__[hash:base64:5]!sass'
-        ]
-      }, {
         test: /\.css$/,
         loader: extractCSS.extract('css')
       }, {

--- a/webpack/development.js
+++ b/webpack/development.js
@@ -10,6 +10,15 @@ const jsLoaderIndex = config.module.loaders
 
 config.module.loaders[jsLoaderIndex].loaders.unshift('react-hot-loader')
 
+config.module.loaders.push({
+  test: /\.scss$/,
+  loaders: [
+    'style',
+    'css?modules&importLoaders=1' +
+      '&localIdentName=[path][local]__[hash:base64:5]!sass'
+  ]
+})
+
 config.output.publicPath = 'http://localhost:8080/'
 
 module.exports = config

--- a/webpack/production.js
+++ b/webpack/production.js
@@ -6,14 +6,14 @@ const extractSCSS = new ExtractTextPlugin('client.css', {
   allChunks: true
 })
 
-const scssLoaderIndex = config.module.loaders
-  .findIndex(loader => String(loader.test) === String(/\.scss$/))
-
-config.module.loaders[scssLoaderIndex].loader = extractSCSS.extract(
-  'style',
-  'css?modules&importLoaders=1' +
-    '&localIdentName=[local]__[hash:base64:5]!sass'
-)
+config.module.loaders.push({
+  test: /\.scss$/,
+  loader: extractSCSS.extract(
+    'style',
+    'css?modules&importLoaders=1' +
+      '&localIdentName=[local]__[hash:base64:5]!sass'
+  )
+})
 
 config.plugins.push(
   extractSCSS,

--- a/webpack/test.js
+++ b/webpack/test.js
@@ -1,5 +1,14 @@
 const config = require('./base')
 
+config.module.loaders.push({
+  test: /\.scss$/,
+  loaders: [
+    'css/locals?modules&importLoaders=1' +
+      '&localIdentName=[path][local]__[hash:base64:5]',
+    'sass'
+  ]
+})
+
 config.target = 'node'
 
 module.exports = config

--- a/webpack/testDebug.js
+++ b/webpack/testDebug.js
@@ -13,6 +13,15 @@ config.entry = {
   test: [`mocha!${index}`]
 }
 
+config.module.loaders.push({
+  test: /\.scss$/,
+  loaders: [
+    'style',
+    'css?modules&importLoaders=1' +
+      '&localIdentName=[path][local]__[hash:base64:5]!sass'
+  ]
+})
+
 config.output.publicPath = 'http://localhost:8081/'
 
 module.exports = config


### PR DESCRIPTION
We had been using a specific commit of style-loader that matched an
outstanding PR that made it work in the node environment
(https://github.com/webpack/style-loader/pull/115).

That PR was rejected with a suggestion to use `css-loader/locals`
instead of the style-loader, so that’s what I’ve done here, which
allows us to go back to the stock version of style-loader.

I reverted the change that pulled the SCSS handling up to the base
webpack config as there is now much less duplication.

I ran into a bunch of strange behavior along the way, but what’s here
seems to work well:

* The decorated style names have an extra `_-_-` prefix on them that
doesn’t show up in the browser environment.
* Using the trailing `!sass` on the loader definition resulted in a
random suffix of either `—sass` or `-sass` or none at all being added
to the style names, and it’s inconsistent enough to potentially make
specs fail.  Moving the other loaders to a separate element of the
array resolves this.
* I found that I don’t actually seem to need the sass loader at all,
and that makes no sense to me at all.  I’ve left it in because it seems
like it really needs to be there, but I am very confused by what I saw.