### PR TITLE
Fix the guard against a missing devToolsExtension

### DIFF
--- a/client/store/devToolsExtension.js
+++ b/client/store/devToolsExtension.js
@@ -3,8 +3,8 @@ import { identity } from 'ramda'
 const isProduction =
   process.env.NODE_ENV === 'production' // eslint-disable-line no-process-env
 
-const devToolsExtension = isProduction
+const devToolsExtension = isProduction || !window.devToolsExtension
   ? identity
-  : (window.devToolsExtension() || identity)
+  : window.devToolsExtension()
 
 export default devToolsExtension


### PR DESCRIPTION
The existing logic raises an error if the extension is not available in
a development environment

Fixed by @house9 on another project; I’m just importing the fix here.