### PR TITLE
Eliminate the need to import specHelper everywhere

### DIFF
--- a/client/__tests__/index.js
+++ b/client/__tests__/index.js
@@ -1,3 +1,5 @@
+import './specHelper'
+
 const context = require.context('..', true, /.+-spec\.js$/)
 
 context.keys().forEach(context)

--- a/client/components/layout/Block/__tests__/Block-spec.js
+++ b/client/components/layout/Block/__tests__/Block-spec.js
@@ -1,4 +1,3 @@
-import '__tests__/specHelper'
 import React from 'react'
 import expectReactShallow from 'expect-react-shallow'
 

--- a/client/components/layout/Container/__tests__/Container-spec.js
+++ b/client/components/layout/Container/__tests__/Container-spec.js
@@ -1,4 +1,3 @@
-import '__tests__/specHelper'
 import React from 'react'
 import expectReactShallow from 'expect-react-shallow'
 

--- a/client/components/layout/Content/__tests__/Content-spec.js
+++ b/client/components/layout/Content/__tests__/Content-spec.js
@@ -1,4 +1,3 @@
-import '__tests__/specHelper'
 import React from 'react'
 import expectReactShallow from 'expect-react-shallow'
 

--- a/client/components/layout/Frame/__tests__/Frame-spec.js
+++ b/client/components/layout/Frame/__tests__/Frame-spec.js
@@ -1,4 +1,3 @@
-import '__tests__/specHelper'
 import React from 'react'
 import expectReactShallow from 'expect-react-shallow'
 

--- a/client/components/layout/internal/Base/__tests__/Base-spec.js
+++ b/client/components/layout/internal/Base/__tests__/Base-spec.js
@@ -1,4 +1,3 @@
-import '__tests__/specHelper'
 import React from 'react'
 import expectReactShallow from 'expect-react-shallow'
 import { expect } from 'chai'

--- a/client/utils/__tests__/api-spec.js
+++ b/client/utils/__tests__/api-spec.js
@@ -1,5 +1,4 @@
 /* eslint-disable camelcase */
-import '__tests__/specHelper'
 import { expect } from 'chai'
 import { prop } from 'ramda'
 import sinon from 'sinon'

--- a/client/utils/__tests__/form-spec.js
+++ b/client/utils/__tests__/form-spec.js
@@ -1,4 +1,3 @@
-import '__tests__/specHelper'
 import { expect } from 'chai'
 import sinon from 'sinon'
 

--- a/mocha-webpack.opts
+++ b/mocha-webpack.opts
@@ -1,4 +1,5 @@
 --colors
+--require client/__tests__/specHelper.js
 --reporter spec
 --webpack-config webpack.config.js
 client/**/*-spec.js

--- a/package.json
+++ b/package.json
@@ -85,6 +85,7 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",
     "webpack-dev-server": "1.14.0",
+    "webpack-node-externals": "^1.0.0",
     "whatwg-fetch": "^0.11.0"
   },
   "babel": {

--- a/webpack/test.js
+++ b/webpack/test.js
@@ -1,4 +1,5 @@
 const config = require('./base')
+const nodeExternals = require('webpack-node-externals')
 
 config.module.loaders.push({
   test: /\.scss$/,
@@ -9,6 +10,11 @@ config.module.loaders.push({
   ]
 })
 
+// Don't run linters in this environment.
+// We get a number of false positives due to the handling of node externals.
+config.module.preLoaders = []
+
+config.externals = [nodeExternals()]
 config.target = 'node'
 
 module.exports = config


### PR DESCRIPTION
While the [issue I opened on mocha-webpack](https://github.com/zinserjan/mocha-webpack/issues/1) is
still outstanding, the author’s suggestion is to use `webpack-node-externals`.  We tried that initially, but that results in numerous firings of the `import/no-unresolved` lint rule.

After conferring with @lexun, we decided to go back to that approach and instead disable the linters when doing `npm run test`.  They still run with `npm run build`, `npm run test:debug`, and `npm run dev`.

If the above-mentioned issue gets resolved, then we can go back to running the linters in all environments.