### PR TITLE
Always run eslint in the production environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_ENV=production ./node_modules/.bin/webpack",
     "dev": "webpack-dev-server --devtool eval --progress --colors --hot --history-api-fallback",
-    "lint": "eslint 'client/**/*.js' && sass-lint -v",
+    "lint": "NODE_ENV=production eslint 'client/**/*.js' && sass-lint -v",
     "postinstall": "npm prune && npm run build",
     "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot --history-api-fallback",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha-webpack",


### PR DESCRIPTION
When running on CI, `npm run lint` will be run with `NODE_ENV=test`.
This causes the test webpack config to be active, and the
`import/no-unresolved` rules don’t work properly with that config.
This ultimately causes CI builds to fail.

So instead, we now explicitly run the `lint` script with
`NODE_ENV=production`.