### PR TITLE
Upgrade mocha-webpack

### DIFF
--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^2.3.4",
     "mocha-loader": "^0.7.1",
-    "mocha-webpack": "^0.1.0",
+    "mocha-webpack": "^0.2.0",
     "node-sass": "^3.4.2",
     "ramda": "^0.19.1",
     "react": "^0.14.5",


### PR DESCRIPTION
mocha-webpack 0.2 adds the `--opts` flag that allows us to put the
`mocha-webpack.opts` anywhere we want.

We don’t actually need that option in the boilerplate itself, but other
projects based on it do, so we want to make that option available.