### PR TITLE
Convert from sasslint-loader to sasslint-webpack-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "redux-thunk": "^1.0.3",
     "sass-lint": "^1.5.1",
     "sass-loader": "^3.1.2",
-    "sasslint-loader": "0.0.1",
+    "sasslint-webpack-plugin": "^1.0.2",
     "sinon": "^2.0.0-pre",
     "sinon-chai": "sjmulder/sinon-chai#pr/sinon-2.0.0-pre",
     "style-loader": "^0.13.1",

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -1,6 +1,7 @@
 const path = require('path')
 const webpack = require('webpack')
 const ExtractTextPlugin = require('extract-text-webpack-plugin')
+const SassLintPlugin = require('sasslint-webpack-plugin')
 
 const extractCSS = new ExtractTextPlugin('vendor.css', {
   allChunks: true
@@ -31,10 +32,6 @@ module.exports = {
       test: /\.js$/,
       exclude: /node_modules/,
       loader: 'eslint-loader'
-    }, {
-      test: /\.scss$/,
-      exclude: /node_modules/,
-      loader: 'sasslint-loader'
     }]
   },
   output: {
@@ -46,13 +43,14 @@ module.exports = {
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.ProvidePlugin({
       fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch'
+    }),
+    new SassLintPlugin({
+      configFile: path.resolve(__dirname, '../.sass-lint.yml'),
+      glob: 'client/**/*.scss'
     })
   ],
   resolve: {
     root: path.resolve(__dirname, '../client'),
     extensions: ['', '.js']
-  },
-  sasslint: {
-    configFile: path.resolve(__dirname, '../.sass-lint.yml')
   }
 }


### PR DESCRIPTION
sasslint-loader has been deprecated in favor of sasslint-webpack-plugin
(see https://github.com/alleyinteractive/sasslint-loader).

On another project, we found that sasslint-loader wasn’t properly
ignoring files according to its config file; the plugin solves that
issue.

The plugin has one issue: it doesn’t seem to use the files and ignored
files from `.sass-lint.yml`, so those settings have to be repeated when
configuring the plugin.  If we want to continue running sasslint from
both webpack and the command-line, we need to maintain these settings
in two places.