### PR TITLE
Use latest mocha-webpack

### DIFF
--- a/mocha-webpack.opts
+++ b/mocha-webpack.opts
@@ -1,5 +1,5 @@
 --colors
---require client/__tests__/specHelper.js
+--include client/__tests__/specHelper.js
 --reporter spec
 --webpack-config webpack.config.js
 client/**/*-spec.js

--- a/package.json
+++ b/package.json
@@ -60,7 +60,7 @@
     "json-loader": "^0.5.4",
     "mocha": "^2.3.4",
     "mocha-loader": "^0.7.1",
-    "mocha-webpack": "^0.2.0",
+    "mocha-webpack": "^0.3.0",
     "node-sass": "^3.4.2",
     "ramda": "^0.19.1",
     "react": "^0.14.5",
@@ -85,7 +85,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",
     "webpack-dev-server": "1.14.0",
-    "webpack-node-externals": "^1.0.0",
     "whatwg-fetch": "^0.11.0"
   },
   "babel": {

--- a/webpack/test.js
+++ b/webpack/test.js
@@ -1,5 +1,4 @@
 const config = require('./base')
-const nodeExternals = require('webpack-node-externals')
 
 config.module.loaders.push({
   test: /\.scss$/,
@@ -10,11 +9,6 @@ config.module.loaders.push({
   ]
 })
 
-// Don't run linters in this environment.
-// We get a number of false positives due to the handling of node externals.
-config.module.preLoaders = []
-
-config.externals = [nodeExternals()]
 config.target = 'node'
 
 module.exports = config


### PR DESCRIPTION
The latest mocha-webpack adds a `--include` option that works like `--require`, but instead includes the file into the webpack bundle.  We use it for our spec helper file which makes it available to our specs
even when using `--watch`.

Bottom line: We can now include our specHelper in one place; we no longer need webpack-node-externals, and we can keep the linters turned on for test runs (we had them disabled before due a conflict with webpack-node-externals).