### PR TITLE
Use source maps for mocha-webpack

### DIFF
--- a/mocha-webpack.opts
+++ b/mocha-webpack.opts
@@ -1,5 +1,6 @@
 --colors
 --include client/__tests__/specHelper.js
 --reporter spec
+--require source-map-support/register
 --webpack-config webpack.config.js
 client/**/*-spec.js

--- a/package.json
+++ b/package.json
@@ -81,6 +81,7 @@
     "sasslint-webpack-plugin": "^1.0.2",
     "sinon": "^2.0.0-pre",
     "sinon-chai": "sjmulder/sinon-chai#pr/sinon-2.0.0-pre",
+    "source-map-support": "^0.4.0",
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.12.9",

--- a/webpack/test.js
+++ b/webpack/test.js
@@ -1,5 +1,7 @@
 const config = require('./base')
 
+config.devtool = 'cheap-module-source-map'
+
 config.module.loaders.push({
   test: /\.scss$/,
   loaders: [


### PR DESCRIPTION
This allows us to see where our tests actually fail.