### PR TITLE
Fail the build when there are lint warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "build": "NODE_ENV=production ./node_modules/.bin/webpack",
     "dev": "webpack-dev-server --devtool eval --progress --colors --hot --history-api-fallback",
-    "lint": "NODE_ENV=production eslint 'client/**/*.js' && sass-lint -v",
+    "lint": "NODE_ENV=production eslint 'client/**/*.js' --max-warnings 0 && sass-lint -v --max-warnings 0",
     "postinstall": "npm prune && npm run build",
     "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot --history-api-fallback",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha-webpack",


### PR DESCRIPTION
Both eslint and sass-lint now take a `--max-warnings` flag, so use that
to cause the build to fail if there are any warnings.

Fixes #56 