### PR TITLE
Remove explicit dependency on whatwg-fetch

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,8 +83,7 @@
     "style-loader": "^0.13.1",
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
-    "webpack-dev-server": "1.14.0",
-    "whatwg-fetch": "^0.11.0"
+    "webpack-dev-server": "1.14.0"
   },
   "babel": {
     "presets": [

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -41,9 +41,6 @@ module.exports = {
   plugins: [
     extractCSS,
     new webpack.optimize.OccurenceOrderPlugin(),
-    new webpack.ProvidePlugin({
-      fetch: 'imports?this=>global!exports?global.fetch!whatwg-fetch'
-    }),
     new SassLintPlugin({
       configFile: path.resolve(__dirname, '../.sass-lint.yml'),
       glob: 'client/**/*.scss'


### PR DESCRIPTION
We don’t use fetch directly; we use it via redux-api-middleware which
has its own dependency configured already (via isomorphic-fetch).