### PR TITLE
npm script improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 node_modules/
 public/
 .tmp/
+.opt-in
+.opt-out

--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,3 @@
 node_modules/
 public/
 .tmp/
-.opt-in
-.opt-out

--- a/package.json
+++ b/package.json
@@ -6,12 +6,15 @@
   "scripts": {
     "build": "NODE_ENV=production ./node_modules/.bin/webpack",
     "dev": "webpack-dev-server --devtool eval --progress --colors --hot --history-api-fallback",
-    "lint": "NODE_ENV=production eslint 'client/**/*.js' --max-warnings 0 && sass-lint -v --max-warnings 0",
+    "lint": "npm-run-all --parallel lint:*",
+    "lint:js": "NODE_ENV=production eslint 'client/**/*.js' --max-warnings 0",
+    "lint:sass": "NODE_ENV=production sass-lint -v --max-warnings 0",
     "postinstall": "npm prune && npm run build",
     "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot --history-api-fallback",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha-webpack",
     "test:debug": "NODE_ENV=test-debug webpack-dev-server --hot --inline",
-    "test:watch": "npm run test -- --watch"
+    "test:watch": "npm run test -- --watch",
+    "validate": "npm-run-all --parallel test lint"
   },
   "repository": {
     "type": "git",
@@ -61,6 +64,7 @@
     "mocha-loader": "^0.7.1",
     "mocha-webpack": "^0.4.0",
     "node-sass": "^3.7.0",
+    "npm-run-all": "^2.2.2",
     "ramda": "^0.21.0",
     "react": "^15.1.0",
     "react-addons-test-utils": "^15.1.0",

--- a/package.json
+++ b/package.json
@@ -16,6 +16,13 @@
     "test:watch": "npm run test -- --watch --reporter min",
     "validate": "npm-run-all --parallel test lint"
   },
+  "config": {
+    "ghooks": {
+      "pre-push": "opt --out pre-push --exec 'npm run validate'",
+      "post-checkout": "opt --out post-checkout --exec 'npm install'",
+      "post-merge": "opt --out post-merge --exec 'npm install'"
+    }
+  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CodingZeal/react-boilerplate.git"
@@ -88,6 +95,10 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
     "webpack-dev-server": "1.14.0"
+  },
+  "devDependencies": {
+    "ghooks": "^1.2.4",
+    "opt-cli": "^1.4.2"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -16,13 +16,6 @@
     "test:watch": "npm run test -- --watch --reporter min",
     "validate": "npm-run-all --parallel test lint"
   },
-  "config": {
-    "ghooks": {
-      "pre-push": "opt --out pre-push --exec 'npm run validate'",
-      "post-checkout": "opt --out post-checkout --exec 'npm install'",
-      "post-merge": "opt --out post-merge --exec 'npm install'"
-    }
-  },
   "repository": {
     "type": "git",
     "url": "git+https://github.com/CodingZeal/react-boilerplate.git"
@@ -95,10 +88,6 @@
     "url-loader": "^0.5.7",
     "webpack": "^1.13.1",
     "webpack-dev-server": "1.14.0"
-  },
-  "devDependencies": {
-    "ghooks": "^1.2.4",
-    "opt-cli": "^1.4.2"
   },
   "babel": {
     "presets": [

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "starterapp": "webpack-dev-server --config webpack/starterApp.js --devtool eval --progress --colors --hot --history-api-fallback",
     "test": "NODE_ENV=test ./node_modules/.bin/mocha-webpack",
     "test:debug": "NODE_ENV=test-debug webpack-dev-server --hot --inline",
-    "test:watch": "npm run test -- --watch",
+    "test:watch": "npm run test -- --watch --reporter min",
     "validate": "npm-run-all --parallel test lint"
   },
   "repository": {


### PR DESCRIPTION
This PR implements the following improvements to the npm scripts in `package.json`:

* Split the `lint` script into `lint:js` and `lint:sass`
* Add a `validate` task that runs the tests and linters
* Add `npm-run-all` and use it to:
  * Run linters in parallel with `npm run lint`
  * Run tests and linters in parallel with `npm run validate`
* Modify `npm run test:watch` to use the `min` reporter. As the test suite grows, the output from the default reporter gets very verbose.  The `min` reporter shows just the results and also clears the console first, so it makes it very handy in a small terminal window in your editor.  `npm test` continues to use the default (`spec`) reporter.