### PR TITLE
Constrain sinon version to 2.0.0-pre

### DIFF
--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "sass-lint": "^1.8.0",
     "sass-loader": "^3.2.0",
     "sasslint-webpack-plugin": "^1.0.3",
-    "sinon": "^2.0.0-pre",
+    "sinon": "=2.0.0-pre",
     "sinon-chai": "sjmulder/sinon-chai#pr/sinon-2.0.0-pre",
     "source-map-support": "^0.4.0",
     "style-loader": "^0.13.1",


### PR DESCRIPTION
With recent updates to the `package.json` file, `npm install` will fail to meet sibling sinon-chai's peer dependency requirements. This PR constrains the sinon version to 2.0.0-pre, which resolves the issue (at least until sinon 2.0.0 is released).