### PR TITLE
Resolve .scss extensions automatically

### DIFF
--- a/client/modules/sample/components/Header/index.js
+++ b/client/modules/sample/components/Header/index.js
@@ -1,6 +1,6 @@
 import React from 'react'
 
-import styles from './styles.scss'
+import styles from './styles'
 
 export default function Header() {
   return (

--- a/webpack/base.js
+++ b/webpack/base.js
@@ -48,6 +48,6 @@ module.exports = {
   ],
   resolve: {
     root: path.resolve(__dirname, '../client'),
-    extensions: ['', '.js']
+    extensions: ['', '.js', '.scss']
   }
 }


### PR DESCRIPTION
All of our React projects have added `.scss` as an extension that Webpack resolves automatically, so add it to the boilerplate so that it’s on by default in future projects.