### PR TITLE
Remove explicit dependency on history

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,7 +55,6 @@
     "file-loader": "^0.9.0",
     "flux-standard-action": "^0.6.0",
     "foundation-apps": "^1.2.0",
-    "history": "^3.0.0",
     "humps": "^1.1.0",
     "imports-loader": "^0.6.5",
     "json-loader": "^0.5.4",


### PR DESCRIPTION
We only use history indirectly via react-router, so we don’t need to depend on it explicitly.

Closes #88.