### PR TITLE
Check for FSAs in reducers

### DIFF
--- a/client/utils/createReducer.js
+++ b/client/utils/createReducer.js
@@ -1,6 +1,29 @@
+import { isFSA } from 'flux-standard-action'
 import { identity, propOr } from 'ramda'
 
-export default function createReducer(initialState, handlers) {
-  return (state = initialState, action) =>
-    propOr(identity, action.type, handlers)(state, action)
+class NonStandardAction {
+  constructor(action) {
+    this.action = action
+    this.message =
+      'attempting to handle an action that is not a flux-standard-action'
+    this.stack = (new Error()).stack
+    this.toString = () => `${this.message}: ${JSON.stringify(this.action)}`
+  }
 }
+
+const throwIfNotFSA = action => {
+  if (isFSA(action)) return
+
+  throw new NonStandardAction(action)
+}
+
+// eslint-disable-next-line no-process-env
+const isProduction = process.env.NODE_ENV === 'production'
+const ensureIsFSA = isProduction ? identity : throwIfNotFSA
+
+export default (initialState, handlers) =>
+  (state = initialState, action) => {
+    ensureIsFSA(action)
+
+    return propOr(identity, action.type, handlers)(state, action)
+  }

--- a/client/utils/nullAction.js
+++ b/client/utils/nullAction.js
@@ -1,0 +1,1 @@
+export default { type: '__NULL_ACTION__' }


### PR DESCRIPTION
In non-production environments, check each action coming through a reducer to make sure it satisfies the
[flux-standard-action](https://github.com/acdlite/flux-standard-action) spec.

In reducer specs, you’ll often want to do `const initialState = reducer(undefined, {})`.  This will fail the new check.  Instead, you can use the provided `nullAction` action (in `utils/nullAction.js`) and do `const initialState = reducer(undefined, nullAction)` instead.

One potential issue with this PR:  redux-form 5.x actions are not FSA-compliant.  We have two options:

1) Add a guard to the FSA check to explicitly ignore redux-form actions.
2) Upgrade to redux-form 6.x, which does use FSA-compliant actions.

We include redux-form in the boilerplate, but don’t have any code that uses it yet, so all of the tests pass as-is.  But projects that use it to do more will run into this issue.