### PR TITLE
Add more specs for callApi header processing

### DIFF
--- a/client/utils/__tests__/api-spec.js
+++ b/client/utils/__tests__/api-spec.js
@@ -56,6 +56,31 @@ describe('tranformCallDescriptor', () => {
         'Content-Type': 'application/json'
       })
     })
+
+    it('can override the Content-Type header', () => {
+      const action = {
+        headers: {
+          'Content-Type': 'text/plain'
+        }
+      }
+
+      expect(apiAction(action).headers).to.contain({
+        'Content-Type': 'text/plain'
+      })
+    })
+
+    it('merges in additional headers', () => {
+      const action = {
+        headers: {
+          Authorization: 'Bearer TOKEN'
+        }
+      }
+
+      expect(apiAction(action).headers).to.contain({
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer TOKEN'
+      })
+    })
   })
 
   describe('body', () => {


### PR DESCRIPTION
Add missing specs for `callApi`’s ability to allow the `Content-Type`header to be overridden and to merge in any additional headers provided by the caller.